### PR TITLE
fix: do not use hardcoded bash path when decorating commands

### DIFF
--- a/src/snakemake_software_deployment_plugin_container/__init__.py
+++ b/src/snakemake_software_deployment_plugin_container/__init__.py
@@ -207,7 +207,7 @@ class RuntimeManager:
             f" {self.workdir_option()} {getcwd()!r}"  # Working directory inside container
             f" {mountpoints}"
             f" {self.image_uri()}"  # Container image
-            " /bin/bash"  # Shell executable
+            " bash"  # Shell executable
             f" -c {shlex.quote(cmd)}"  # The command to execute
         )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell executable resolution within containers for enhanced compatibility across different container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->